### PR TITLE
Add option to adjust the amount of connection attempts

### DIFF
--- a/docs/modules/SensorManager.md
+++ b/docs/modules/SensorManager.md
@@ -32,7 +32,9 @@ Wrapper class for ImuSensor objects
 #### \_\_init\_\_
 
 ```python
-def __init__(sensor_names: List[str], sample_rate: int = 100)
+def __init__(sensor_names: List[str],
+             sample_rate: int = 100,
+             connection_attempts: int = 3)
 ```
 
 Construct a SensorManager object


### PR DESCRIPTION
When creating a SensorManager you can now supply an additional optional parameter to adjust the amount of connection attempts that will be made to establish a connection to the IMU(s)

Fixes random NoneType errors and helps with initial connection consistency