### PR TITLE
Blocking now doesn't accidentally clear the queue

### DIFF
--- a/src/CreaTeBME/SensorManager.py
+++ b/src/CreaTeBME/SensorManager.py
@@ -47,8 +47,9 @@ class SensorManager:
             self._thread.daemon = True
             self._thread.start()
         self._is_running = True
-        while any([len(self.get_measurements()[key]) == 0 for key in list(self._queue.keys())]):
+        while any([len(self._queue[key]) == 0 for key in list(self._queue.keys())]):
             pass
+        self._clear_queue()
 
     def stop(self) -> None:
         """


### PR DESCRIPTION
Short explanation of what was broken and how it was fixed:

Whenever get_measurements() is called, it also clears the queue. This meant that if one of the sensors had sent data while the other hadn't sent any in the exact same frame, the data of the first sensor would get cleared. This means that even if the second sensor sent data a short time after this, the while loop would still continue because it would now think the first sensor hadn't sent any data.

We now access the queue directly to make sure we don't clear it. Then when we're sure both sensors have sent data we clear it once to make sure both sensors have the around same amount of data points.